### PR TITLE
Fix pipenv

### DIFF
--- a/dotfiles/archLinux/.shellSpecifics
+++ b/dotfiles/archLinux/.shellSpecifics
@@ -146,6 +146,9 @@ export _JAVA_AWT_WM_NONREPARENTING=1
 # For Key signatures
 export GPG_TTY=$(tty)
 
+# Fixes pipenv
+export WORKON_HOME=~/.venvs
+
 # Use pacman's keyring for gnupg (only temporary)
 #export GNUPGHOME=/etc/pacman.d/gnupg
 


### PR DESCRIPTION
With python 3.7, pipenv seems to set a weird path without this.